### PR TITLE
s/require/include

### DIFF
--- a/loudnumbers_norns.lua
+++ b/loudnumbers_norns.lua
@@ -28,7 +28,7 @@ musicutil = require("musicutil")
 local p_option = require "core/params/option"
 -- Import library to update parameters (Thanks Eigen!)
 
-csv = require(_path.code .. "loudnumbers_norns/lib/csv")
+csv = include("lib/csv")
 -- Import csv library: https://github.com/geoffleyland/lua-csv
 
 engine.name = "PolyPerc"


### PR DESCRIPTION
use the norns function `include` for local libs rather than the lua function `require`. this has verious benefits; most pertinently it will work more reliably in desktop and virtual environments.

(wasn't sure if you wanted the `csv` module global on purpose, maybe handy for REPL use, so left it that way.)